### PR TITLE
Avoiding issues when the fixture is empty

### DIFF
--- a/examples/PizzaTraitTest.php
+++ b/examples/PizzaTraitTest.php
@@ -32,7 +32,10 @@ class PizzaTraitTest extends \PHPUnit_Framework_TestCase {
 		'orders' => [
 			['size' => 'large', 'toppings' => ['cheese', 'ham']],
 			['size' => 'medium', 'toppings' => ['cheese']]
-		]
+		],
+		'carts' => [
+			// Intentionally empty
+		],
 	];
 
 	/**

--- a/src/DataSet/DataSet.php
+++ b/src/DataSet/DataSet.php
@@ -66,7 +66,9 @@ class DataSet {
 	 */
 	public function buildCollections() {
 		foreach ($this->fixture as $collection => $data) {
-			$this->connection->collection($collection)->insertMany($data);
+			if (!empty($data)) {
+				$this->connection->collection($collection)->insertMany($data);
+			}
 		}
 		return $this;
 	}


### PR DESCRIPTION
This happens for cases where the user wants to drop/truncate the collection and not insert any data.