### PR TITLE
Support mongodb/mongodb 1.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,11 @@
     },
     "require": {
         "php": ">=5.5.0",
-        "ext-mongodb": "*",
-        "mongodb/mongodb": ">=1.1.1 <1.4"
+        "ext-mongodb": "^1.5.0",
+        "mongodb/mongodb": ">=1.1.1 <1.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.6.0"
+        "phpunit/phpunit": "~4.8.0"
     },
     "config": {
         "bin-dir": "bin"


### PR DESCRIPTION
## Problem 

`mongodb/mongodb` is now 1.4.3 and supports MongoDB 4.0 which I want to upgrade to. Unfortunately `zumba/mongounit` has a constraint and stop at `mongodb/mongodb` 1.3

I'd like to make this change to support the new `mongodb/mongodb`