### PR TITLE
Bump mongodb/mongodb to 1.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,12 @@
         "issues": "https://github.com/zumba/mongounit/issues"
     },
     "require": {
-        "php": ">=5.5.0",
-        "ext-mongodb": "^1.5.0",
-        "mongodb/mongodb": ">=1.1.1 <1.5"
+        "php": ">=5.6.0",
+        "ext-mongodb": "^1.6.0",
+        "mongodb/mongodb": "^1.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8.0"
+        "phpunit/phpunit": "~5.7.0"
     },
     "config": {
         "bin-dir": "bin"


### PR DESCRIPTION
## Problem 

`mongodb/mongodb` is now 1.5. I'd like to make this change to support the new `mongodb/mongodb`

I already ran the test on my local.